### PR TITLE
Silence spec warnings

### DIFF
--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe InvalidUTF8Rejector::Middleware do
     end
 
     it "should reject invalid UTF-8 chars in the query_string without calling the app" do
-      # Set params to nil.  Without this, it defaults to empty hash, and rack-test tries to merge this with 
+      # Set params to nil.  Without this, it defaults to empty hash, and rack-test tries to merge this with
       # the given params which blows up with an invalid UTF-8 error before reaching our code
       get "/foo?ba%a0r", nil
       expect(last_response.status).to eq(400)
@@ -43,7 +43,7 @@ RSpec.describe InvalidUTF8Rejector::Middleware do
     end
 
     it "should reject malformed UTF-8 chars in the query_string without calling the app" do
-      # Set params to nil.  Without this, it defaults to empty hash, and rack-test tries to merge this with 
+      # Set params to nil.  Without this, it defaults to empty hash, and rack-test tries to merge this with
       # the given params which blows up with an invalid UTF-8 error before reaching our code
       get "/foo?bar=br54ba%9CAQ%C4%FD%928owse", nil
       expect(last_response.status).to eq(400)
@@ -53,13 +53,13 @@ RSpec.describe InvalidUTF8Rejector::Middleware do
 
   describe "handling invalid % encoded requests" do
     it "should reject invalid % encoding in the path without calling the app" do
-      status, headers, body = raw_rack_get('/foo%+bar')
+      status, _, _ = raw_rack_get('/foo%+bar')
       expect(status).to eq(400)
       expect(@inner_app_called).to eq(false)
     end
 
     it "should reject invalid % encoding in the query_string without calling the app" do
-      status, headers, body = raw_rack_get('/foo', 'bar%=baz')
+      status, _, _ = raw_rack_get('/foo', 'bar%=baz')
       expect(status).to eq(400)
       expect(@inner_app_called).to eq(false)
     end
@@ -75,6 +75,6 @@ RSpec.describe InvalidUTF8Rejector::Middleware do
       'SERVER_NAME' => 'example.org',
       'SERVER_PORT' => 80,
     }
-    status, headers, body = app.call(env)
+    app.call(env)
   end
 end


### PR DESCRIPTION
This change silences the following warnings:

```
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:56: warning: assigned but unused variable - headers
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:56: warning: assigned but unused variable - body
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:62: warning: assigned but unused variable - headers
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:62: warning: assigned but unused variable - body
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:78: warning: assigned but unused variable - status
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:78: warning: assigned but unused variable - headers
/home/travis/build/alext/invalid_utf8_rejector/spec/middleware_spec.rb:78: warning: assigned but unused variable - body
```

(see https://travis-ci.org/alext/invalid_utf8_rejector/jobs/54229733)