### PR TITLE
Loosen rack dependency to include rack 2.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,16 @@ rvm:
   - "2.1"
   - "2.2"
   - "2.3.0"
+gemfile:
+  - gemfiles/Gemfile.rack-1.6
+  - gemfiles/Gemfile.rack-2.0
+  - Gemfile
+# rack 2.0 doesn't support ruby < 2.2.2
+matrix:
+  exclude:
+  - rvm: "1.9.3"
+    gemfile: gemfiles/Gemfile.rack-2.0
+  - rvm: "2.1"
+    gemfile: gemfiles/Gemfile.rack-2.0
+  - rvm: "2.2"
+    gemfile: gemfiles/Gemfile.rack-2.0

--- a/gemfiles/Gemfile.rack-1.6
+++ b/gemfiles/Gemfile.rack-1.6
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "rack", '~> 1.6.0'

--- a/gemfiles/Gemfile.rack-2.0
+++ b/gemfiles/Gemfile.rack-2.0
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "rack", '2.0.0.alpha'

--- a/invalid_utf8_rejector.gemspec
+++ b/invalid_utf8_rejector.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", "~> 1.0"
+  spec.add_dependency "rack", ">= 1.0", "< 3"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Rails 5 will ship with Rack 2.

This change also builds against both rack 1.6 and 2.0.0