### PR TITLE
Remove runtime dependency on rack

### DIFF
--- a/invalid_utf8_rejector.gemspec
+++ b/invalid_utf8_rejector.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rack", "~> 1.0"
-
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test", "0.6.2"


### PR DESCRIPTION
This gem provides rack middleware but doesn't actually rely on the
rack gem itself.

This makes the gem more resilient against rack gem versions.